### PR TITLE
Add uart config logging

### DIFF
--- a/lib/rtu/master.ex
+++ b/lib/rtu/master.ex
@@ -141,7 +141,7 @@ defmodule Modbux.Rtu.Master do
     timeout = Keyword.get(params, :timeout, @timeout)
     tty = Keyword.fetch!(params, :tty)
     Logger.debug("(#{__MODULE__}) Starting Modbux Master at \"#{tty}\"")
-    uart_opts = Keyword.get(params, :uart_otps, speed: @speed, rx_framing_timeout: @timeout)
+    uart_opts = Keyword.get(params, :uart_opts, speed: @speed, rx_framing_timeout: @timeout)
     {:ok, u_pid} = UART.start_link()
     UART.open(u_pid, tty, [framing: {Framer, behavior: :master}, active: false] ++ uart_opts)
 
@@ -196,7 +196,7 @@ defmodule Modbux.Rtu.Master do
     parent_pid = if active, do: parent_pid
     timeout = Keyword.get(params, :timeout, state.timeout)
     tty = Keyword.get(params, :tty, state.tty)
-    uart_opts = Keyword.get(params, :uart_otps, state.uart_opts)
+    uart_opts = Keyword.get(params, :uart_opts, state.uart_opts)
     Logger.debug("(#{__MODULE__}) Starting Modbux Master at \"#{tty}\"")
 
     UART.close(state.uart_pid)

--- a/lib/rtu/master.ex
+++ b/lib/rtu/master.ex
@@ -144,6 +144,7 @@ defmodule Modbux.Rtu.Master do
     uart_opts = Keyword.get(params, :uart_opts, speed: @speed, rx_framing_timeout: @timeout)
     {:ok, u_pid} = UART.start_link()
     UART.open(u_pid, tty, [framing: {Framer, behavior: :master}, active: false] ++ uart_opts)
+    Logger.debug("(#{__MODULE__}) Reported UART configuration: \"#{inspect(UART.configuration(u_pid))}\"")
 
     state = %Master{
       parent_pid: parent_pid,

--- a/lib/rtu/slave.ex
+++ b/lib/rtu/slave.ex
@@ -16,7 +16,7 @@ defmodule Modbux.Rtu.Slave do
   defstruct model_pid: nil,
             uart_pid: nil,
             tty: nil,
-            uart_otps: nil,
+            uart_opts: nil,
             parent_pid: nil
 
   @doc """
@@ -126,17 +126,17 @@ defmodule Modbux.Rtu.Slave do
     tty = Keyword.fetch!(params, :tty)
     model = Keyword.fetch!(params, :model)
     Logger.debug("(#{__MODULE__}) Starting Modbux Slave at \"#{tty}\"")
-    uart_otps = Keyword.get(params, :uart_otps, speed: @speed, rx_framing_timeout: @timeout)
+    uart_opts = Keyword.get(params, :uart_opts, speed: @speed, rx_framing_timeout: @timeout)
     {:ok, model_pid} = Shared.start_link(model: model)
     {:ok, u_pid} = UART.start_link()
-    UART.open(u_pid, tty, [framing: {Framer, behavior: :slave}] ++ uart_otps)
+    UART.open(u_pid, tty, [framing: {Framer, behavior: :slave}] ++ uart_opts)
 
     state = %Slave{
       model_pid: model_pid,
       parent_pid: parent_pid,
       tty: tty,
       uart_pid: u_pid,
-      uart_otps: uart_otps
+      uart_opts: uart_opts
     }
 
     {:ok, state}


### PR DESCRIPTION
# Dumps actual UART configuration into debug log

(feel free to close this one)
Logging the actual configuration of port turned to be super helpful, when working with different then default UART config. I got cought by the fact, that `modbux` and `Circuits.UART` defaults are different, as I've initially tried to pass only settings different to `modbux` defaults. What also added to confusion was the fact, that initially, I though that defaults are _per attribute_ and not for `uart_opts` as a whole.

Sorry for the other included commit. It followed #9 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
