### PR TITLE
Add option to not close tcp on passive mode timeout

### DIFF
--- a/lib/tcp/client.ex
+++ b/lib/tcp/client.ex
@@ -18,6 +18,7 @@ defmodule Modbux.Tcp.Client do
             socket: nil,
             timeout: @to,
             active: false,
+            close_on_timeout: true,
             transid: 0,
             status: nil,
             d_pid: nil,
@@ -41,6 +42,8 @@ defmodule Modbux.Tcp.Client do
     * `timeout` - is the connection timeout.
     * `active` - (`true` or `false`) specifies whether data is received as
         messages (mailbox) or by calling `confirmation/1` each time `request/2` is called.
+    * `close_on_timeout` - (`true` or `false`) specifies whether the tcp port is closed
+        when a timeout occurs (only in passive mode). Defaults to `true`.
 
     The messages (when active mode is true) have the following form:
 
@@ -135,6 +138,7 @@ defmodule Modbux.Tcp.Client do
     port = args[:tcp_port] || @port
     ip = args[:ip] || @ip
     timeout = args[:timeout] || @timeout
+    close_on_timeout = Keyword.get(args, :close_on_timeout, true)
     status = :closed
 
     active =
@@ -144,7 +148,15 @@ defmodule Modbux.Tcp.Client do
         args[:active]
       end
 
-    state = %Client{ip: ip, tcp_port: port, timeout: timeout, status: status, active: active}
+    state = %Client{
+      ip: ip,
+      tcp_port: port,
+      timeout: timeout,
+      status: status,
+      active: active,
+      close_on_timeout: close_on_timeout
+    }
+
     {:ok, state}
   end
 
@@ -295,7 +307,9 @@ defmodule Modbux.Tcp.Client do
             {:error, reason} ->
               Logger.error("(#{__MODULE__}, :confirmation) reason: #{inspect(reason)}")
               # cerrar?
-              new_state = close_socket(state)
+              new_state =
+                if reason == :timeout and not state.close_on_timeout, do: state, else: close_socket(state)
+
               new_state = %Client{new_state | cmd: nil, msg_len: 0}
               {:reply, {:error, reason}, new_state}
           end


### PR DESCRIPTION
# Description

In my usage of your library I would like to continue sending requests to a server, even if one times out. Therefore I have added an option to the `Modbux.Tcp.Client` module that allows users to control whether the TCP connection should be closed when a timeout occurs in passive mode. The option `close_on_timeout` is set to true by default, so as to be backwards compatible.

**Timeout handling logic:**
- Modified the timeout error handling in `:confirmation` so that the socket is only closed on timeout if `close_on_timeout` is set to `true`.

## Type of change 

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (the new option has been added to the documentation for the tcp client module)

# How Has This Been Tested?

The change is very minor, albeit hard to test well. I have not added any tests for it.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `close_on_timeout` option (default true) to control whether the TCP socket is closed on passive-mode timeouts and updates timeout handling accordingly.
> 
> - **Modbus TCP Client (`lib/tcp/client.ex`)**
>   - **Option**: Introduces `close_on_timeout` (default `true`) in `Client` struct and init args to control socket closure on passive-mode timeouts.
>   - **Behavior**: In `:confirmation`, only closes socket on `:timeout` when `close_on_timeout` is `true`; otherwise keeps connection open and resets cmd/msg state.
>   - **Docs**: Updates module docs to document the new `close_on_timeout` option.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6f6b995a8d48cee1ed01d1cdffbab79b2b039c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->